### PR TITLE
Changed the visibility of traits to JvmVisibility.PUBLIC

### DIFF
--- a/plugins/org.eclipse.viatra.cep.vepl/src/org/eclipse/viatra/cep/vepl/jvmmodel/TraitGenerator.xtend
+++ b/plugins/org.eclipse.viatra.cep.vepl/src/org/eclipse/viatra/cep/vepl/jvmmodel/TraitGenerator.xtend
@@ -28,10 +28,10 @@ class TraitGenerator {
 			acceptor.accept(trait.toInterface(trait.traitInterfaceFqn.toString) [
 				for (param : (trait as Trait).parameters.parameters) {
 					members += param.toMethod("get"+param.typedParameter.name.toFirstUpper, param.typedParameter.type)[
-						visibility = JvmVisibility.DEFAULT 
+						visibility = JvmVisibility.PUBLIC 
 					]
 					members += param.toMethod("set"+param.typedParameter.name.toFirstUpper, typeRefBuilder.typeRef("void"))[
-						visibility = JvmVisibility.DEFAULT
+						visibility = JvmVisibility.PUBLIC
 						parameters += param.toParameter(param.typedParameter.name, param.typedParameter.type)
 					]
 				}


### PR DESCRIPTION
The old value was JvmVisibility.DEFAULT --> syntax error (http://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.5.6)
e.g.: 
public interface AxisSelector {
  default boolean getDirX();
}
